### PR TITLE
Fix col_names set to empty [] incorrectly skipping first row

### DIFF
--- a/lib/DBD/CSV.pm
+++ b/lib/DBD/CSV.pm
@@ -23,7 +23,7 @@ use vars qw( @ISA $VERSION $ATTRIBUTION $drh $err $errstr $sqlstate );
 
 @ISA =   qw( DBD::File );
 
-$VERSION     = "0.53";
+$VERSION     = "0.54";
 $ATTRIBUTION = "DBD::CSV $DBD::CSV::VERSION by H.Merijn Brand";
 
 $err      = 0;		# holds error code   for DBI::err
@@ -346,10 +346,10 @@ sub _csv_diag {
 sub fetch_row {
     my ($self, $data) = @_;
 
-    exists $self->{cached_row} and
-	return $self->{row} = delete $self->{cached_row};
-
     my $tbl = $self->{meta};
+
+    exists $tbl->{cached_row} and
+	return $self->{row} = delete $tbl->{cached_row};
 
     my $csv = $self->{csv_csv_in} or
 	return do { $data->set_err ($DBI::stderr, "Fetch from undefined handle"); undef };

--- a/t/80_rt.t
+++ b/t/80_rt.t
@@ -295,6 +295,8 @@ sub rt_file {
     eval {
 	ok ($sth->execute, "execute");
 	ok (!$@, "no error");
+    is scalar(@{$sth->fetchall_arrayref}), 2,               # not part of 80078
+        "empty col_names treat skip_first_row as false";
 	};
 
     ok ($dbh->do ("drop table $tbl"),		"drop");


### PR DESCRIPTION
Update DBD/CSV.pm to fix likely coding error that tried to use a
"cached_row" to implement skip_first_row=false with col_names set to
empty but didn't quite work.  Set col_names to empty now has effect
of skip_first_row=false.