### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -51,8 +51,6 @@ MSG
     sleep 5;
     }
 
-use vars qw( $DBI_INC_DIR );
-
 {   my $tmp_dir = File::Spec->tmpdir ();
     if (!$ENV{AUTOMATED_TESTING} &&
          prompt ("Enable the use of $tmp_dir for tests?", "y") =~ m/[Yy]/) {

--- a/lib/DBD/CSV.pm
+++ b/lib/DBD/CSV.pm
@@ -27,17 +27,15 @@ package DBD::CSV;
 
 use strict;
 
-use vars qw( @ISA $VERSION $ATTRIBUTION $drh $err $errstr $sqlstate );
+our @ISA =   qw( DBD::File );
 
-@ISA =   qw( DBD::File );
+our $VERSION     = "0.60";
+our $ATTRIBUTION = "DBD::CSV $DBD::CSV::VERSION by H.Merijn Brand";
 
-$VERSION     = "0.60";
-$ATTRIBUTION = "DBD::CSV $DBD::CSV::VERSION by H.Merijn Brand";
-
-$err      = 0;		# holds error code   for DBI::err
-$errstr   = "";		# holds error string for DBI::errstr
-$sqlstate = "";         # holds error state  for DBI::state
-$drh      = undef;	# holds driver handle once initialized
+our $err      = 0;      # holds error code   for DBI::err
+our $errstr   = "";     # holds error string for DBI::errstr
+our $sqlstate = "";     # holds error state  for DBI::state
+our $drh      = undef;  # holds driver handle once initialized
 
 sub CLONE {		# empty method: prevent warnings when threads are cloned
     } # CLONE
@@ -49,9 +47,8 @@ package DBD::CSV::dr;
 use strict;
 
 use Text::CSV_XS ();
-use vars qw( @ISA @CSV_TYPES );
 
-@CSV_TYPES = (
+our @CSV_TYPES = (
     Text::CSV_XS::IV (), # SQL_TINYINT
     Text::CSV_XS::IV (), # SQL_BIGINT
     Text::CSV_XS::PV (), # SQL_LONGVARBINARY


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under 5.06+.

This dist already uses "our" elsewhere.

$DBI_INC_DIR was dropped from Makefile.PL as it's unused since ea569f38191109fdff98197abeb4cced3a55ba53.